### PR TITLE
UI improvements

### DIFF
--- a/main/apps.py
+++ b/main/apps.py
@@ -1,5 +1,9 @@
 from django.apps import AppConfig
-
+from django.conf import settings
 
 class MainConfig(AppConfig):
     name = 'main'
+
+    # make sure that required custom settings are in place
+    if not hasattr(settings, "VISIT_INFO_CUTOFF_DATE"):
+        raise AttributeError("VISIT_INFO_CUTOFF_DATE is required in your Django settings.")

--- a/main/templates/main/test_rules.html
+++ b/main/templates/main/test_rules.html
@@ -39,6 +39,11 @@
 
     <hr>
     <h3>Visit Information Records since {{ VISIT_INFO_CUTOFF_DATE }}</h3>
+
+    {% with pObj=visits %}
+        {% include 'core/pagination.html' %}
+    {% endwith %}
+
     <table class="table table-bordered">
         <thead class="thead-light">
             <tr>
@@ -116,6 +121,10 @@
             {% endfor %}
         </tbody>
     </table>
+
+    {% with pObj=visits %}
+        {% include 'core/pagination.html' %}
+    {% endwith %}
 
 
 {% endblock %}

--- a/main/views.py
+++ b/main/views.py
@@ -9,6 +9,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.db.models import ProtectedError
 from django.conf import settings
+from django.core.paginator import Paginator
 
 from redcap_importer.models import RedcapConnection
 from .instrument_management import (
@@ -63,7 +64,9 @@ def test_rules(request):
         oVisit = models.CompletedVisit.objects.filter(record_id=entry["record_id"], instance=int(entry["redcap_repeat_instance"])).first()
         entry["completed_visit"] = oVisit
         visits.append(entry)
-    context["visits"] = visits
+    paginated_visits = Paginator(visits, 50)
+    page_number = request.GET.get('page', 1)
+    context["visits"] = paginated_visits.get_page(page_number)
     context["current_page"] = "test_rules"
     context["VISIT_INFO_CUTOFF_DATE"] = settings.VISIT_INFO_CUTOFF_DATE
     return render(request, 'main/test_rules.html', context)


### PR DESCRIPTION
- The view for testing rules was modified to show only 50 visit information records at a time. This will avoid having the HTML for this view get too big if there are a lot of records.
- `VISIT_INFO_CUTOFF_DATE` is required in the Django settings. I added a check that will raise an error when the application starts if that is missing.